### PR TITLE
FEAT_Login_Alarm_Functio_Trim

### DIFF
--- a/client/src/components/Loading/Loading.jsx
+++ b/client/src/components/Loading/Loading.jsx
@@ -1,0 +1,12 @@
+const IsLoading = () => {
+  return (
+    <div className="flex justify-center items-center height 100vh">
+      <div className="flex flex-col items-center">
+        <div className="border-8 border-t-8 rounded-full border-t-indigo-900 w-[50px] h-[50px] animate-spin"></div>
+        <p>Loading...</p>
+      </div>
+    </div>
+  );
+};
+
+export default IsLoading;

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ChangeEvent, FormEvent } from 'react';
 import { Button } from '@material-tailwind/react';
 import { Link } from 'react-router-dom';
@@ -12,11 +13,14 @@ const Login: React.FC = () => {
     email: '',
     password: '',
   });
+
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const userInfo = useAppSelector((state) => state.member);
+  const isLoading = userInfo.isLoading;
   console.log(userInfo);
 
-  const HandleLoginInfo = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleLoginInfo = (e: ChangeEvent<HTMLInputElement>) => {
     const key = e.target.name;
     setLoginInfo({
       ...LoginInfo,
@@ -24,7 +28,7 @@ const Login: React.FC = () => {
     });
   };
 
-  const HandleLogin = async (e: FormEvent<HTMLFormElement>) => {
+  const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (!LoginInfo.email || !LoginInfo.password) {
@@ -33,17 +37,32 @@ const Login: React.FC = () => {
     }
 
     try {
-      await dispatch(fetchUserDetails(LoginInfo.email));
+      const resultAction = await dispatch(fetchUserDetails(LoginInfo.email));
+
+      if (fetchUserDetails.fulfilled.match(resultAction)) {
+        console.log(userInfo.user);
+        alert(`반갑습니다.${resultAction.payload.name} 회원님!`);
+        navigate('/');
+      } else if (fetchUserDetails.rejected.match(resultAction)) {
+        // 서버 200, 304인데 데이터가 없는경우
+        const errorMessage = resultAction.payload as string;
+        alert(errorMessage);
+      }
     } catch (error) {
       console.log(error);
+      alert('서버와 통신오류가 발생했습니다. 로그인을 재시도해주세요');
+      return;
     }
   };
 
   return (
     <div className="flex flex-col item-center justify-center px-[12.5px]">
       <div className="text-2xl font-bold text-center">로그인</div>
+      {/* {isLoading ? (
+        <IsLoading />
+      ) : ( */}
       <div className="flex flex-col justify-center rounded-lg item-center">
-        <form className="flex flex-col gap-2 py-4 rounded-lg" onSubmit={HandleLogin}>
+        <form className="flex flex-col gap-2 py-4 rounded-lg" onSubmit={handleLogin}>
           <label htmlFor="email" className="text-sm">
             이메일
           </label>
@@ -54,7 +73,7 @@ const Login: React.FC = () => {
             className="border-2 text-sm rounded-lg p-2 mb-5 h-[50px]"
             placeholder="이메일을 입력하세요"
             value={LoginInfo.email}
-            onChange={HandleLoginInfo}
+            onChange={handleLoginInfo}
           />
 
           <label htmlFor="password" className="text-sm">
@@ -68,7 +87,7 @@ const Login: React.FC = () => {
             className="border-2 text-sm rounded-lg p-2 mb-8 h-[50px]"
             placeholder="비밀번호를 입력하세요"
             value={LoginInfo.password}
-            onChange={HandleLoginInfo}
+            onChange={handleLoginInfo}
           />
           <Button
             type="submit"
@@ -95,6 +114,7 @@ const Login: React.FC = () => {
           </Button>
         </form>
       </div>
+      {/* )} */}
     </div>
   );
 };

--- a/client/src/redux/slice/MemberSlice.tsx
+++ b/client/src/redux/slice/MemberSlice.tsx
@@ -1,14 +1,24 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { CommonUserType } from 'Types/Types';
 
-const initialState: CommonUserType = {
-  name: '',
-  email: '',
-  teacher: false,
-  id: null as unknown as number,
-  phone: null as unknown as number,
-  img: '',
+type initialStateType = {
+  user: CommonUserType;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+const initialState: initialStateType = {
+  user: {
+    name: '',
+    email: '',
+    teacher: false,
+    id: null as unknown as number,
+    phone: null as unknown as number,
+    img: '',
+  },
+  isLoading: false,
+  isError: false,
 };
 
 export const memberSlice = createSlice({
@@ -16,17 +26,26 @@ export const memberSlice = createSlice({
   initialState,
   reducers: {},
   extraReducers: (builder) => {
-    builder.addCase(fetchUserDetails.fulfilled, (state, action) => {
-      return {
-        ...state,
-        name: action.payload.name,
-        email: action.payload.email,
-        teacher: action.payload.teacher,
-        id: action.payload.id,
-        phone: action.payload.phone,
-        img: action.payload.img,
-      };
-    });
+    builder
+      .addCase(fetchUserDetails.pending, (state) => {
+        state.isLoading = true;
+        state.isError = false;
+      })
+      .addCase(fetchUserDetails.fulfilled, (state, action) => {
+        state.isLoading = false;
+        state.user = {
+          name: action.payload.name,
+          email: action.payload.email,
+          teacher: action.payload.teacher,
+          id: action.payload.id,
+          phone: action.payload.phone,
+          img: action.payload.img,
+        };
+      })
+      .addCase(fetchUserDetails.rejected, (state) => {
+        state.isLoading = false;
+        state.isError = true;
+      });
   },
 });
 
@@ -34,12 +53,24 @@ export default memberSlice.reducer;
 
 export const fetchUserDetails = createAsyncThunk(
   'member/fetchUserDetails',
-  async (email: string) => {
-    const response = await axios.get(
-      `http://localhost:8080/member?email=${email}`
-    );
-    const data = response.data[0];
-    console.log(data);
-    return data;
+  async (email: string, { rejectWithValue }) => {
+    try {
+      const response = await axios.get(`http://localhost:8080/member?email=${email}`);
+      const data = response.data[0];
+      console.log(data);
+      if (!data) {
+        return rejectWithValue('등록된 계정이 없거나 비밀번호가 일치하지 않습니다');
+      }
+      return data;
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      if (!axiosError) {
+        return rejectWithValue('서버와 통신오류가 발생했습니다. 다시 시도해주세요');
+      }
+      if (axiosError.response && axiosError.response.status)
+        // return rejectWithValue('서버와 통신오류' + axiosError.response.status);
+        return rejectWithValue('서버와 통신오류가 발생했습니다. 다시 시도해주세요');
+    }
+    return rejectWithValue('서버와 통신오류가 발생했습니다. 다시 시도해주세요');
   }
 );


### PR DESCRIPTION
1) Private Page와 정보연동 (Thunk 및 Redux) 처리
2) 고객정보 수신과 연동에 대한 에러 Handling

** MemberSlice.txs내에서 axios오류에 대해 어려움이 많아서 코드를 단순하게 수정하였습니다. 
    로그인을 시도하면 지정된 형태로 고객정보를 받아오되, 
    1) 서버는 작동하나 고객정보가 없는 경우는 catch문에서 ( 서버에서는 202, 304출력, user정보는 undefined) 
    2) 서버 미가동인 경우는 catch문에서 에러문구를 정하였습니다.
    
** Login.txs내에서는 axios에 대한 오류 문구를 Thunk에서 받아와서 사용하도록 설정했습니다. 
    isError정보를 기준으로 처리하는게 맞는것 같은데 잘 안됐습니다. 
    json서버가 일치하는 고객정보가 없어도 200을 보내오되 이경우 reducer에서 설정되는 user정보는 undefined이라 
    Thunk에서 주는 rejected에 대한 정보를 그대로 가져와서 처리하는 것으로 했습니다. 