### PR TITLE
[Feat] 강사검색 쿼리 수정. 강사정보는 강사본인만 수정 가능하게 하는거 일단 비활성화

### DIFF
--- a/server/src/main/java/com/codestates/connectInstructor/security/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/codestates/connectInstructor/security/filter/JwtAuthenticationFilter.java
@@ -56,9 +56,9 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     private String delegateAccessToken(Member member) {
         Map<String, Object> claims = new HashMap<>();
-        claims.put("username", member.getEmail());
+        claims.put("email", member.getEmail());
         claims.put("roles", member.getRoles());
-        claims.put("memberId", member.getId());
+        claims.put("id", member.getId());
 
         String subject = member.getEmail();
         Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());

--- a/server/src/main/java/com/codestates/connectInstructor/teacher/controller/TeacherController.java
+++ b/server/src/main/java/com/codestates/connectInstructor/teacher/controller/TeacherController.java
@@ -194,8 +194,8 @@ public class TeacherController {
 
     @GetMapping
     public ResponseEntity getTeachers(@RequestParam String teacherName,
-                                      @RequestParam List<String> subjectNames,
-                                      @RequestParam List<String> regionNames,
+                                      @RequestParam(required = false) List<String> subjectNames,
+                                      @RequestParam(required = false) List<String> regionNames,
                                       @Positive @RequestParam int page,
                                       @Positive @RequestParam int size) {
 

--- a/server/src/main/java/com/codestates/connectInstructor/teacher/dto/TeacherDto.java
+++ b/server/src/main/java/com/codestates/connectInstructor/teacher/dto/TeacherDto.java
@@ -102,6 +102,7 @@ public class TeacherDto {
         private long id;
         private String email;
         private String name;
+        private boolean teacher = true;
         private String phone;
         private String profileImg;
         private String introduction;

--- a/server/src/main/java/com/codestates/connectInstructor/teacher/mapper/TeacherMapper.java
+++ b/server/src/main/java/com/codestates/connectInstructor/teacher/mapper/TeacherMapper.java
@@ -51,6 +51,7 @@ public interface TeacherMapper {
             response.setId(teacher.getId());
             response.setEmail(teacher.getEmail());
             response.setName(teacher.getName());
+            response.setTeacher(true);
             response.setPhone(teacher.getPhone());
             response.setProfileImg(teacher.getProfileImg());
             response.setIntroduction(teacher.getIntroduction());

--- a/server/src/main/java/com/codestates/connectInstructor/teacher/repository/TeacherRepository.java
+++ b/server/src/main/java/com/codestates/connectInstructor/teacher/repository/TeacherRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 public interface TeacherRepository extends JpaRepository<Teacher, Long> {
     Optional<Teacher> findByEmail(String email);
 
-    @Query("SELECT DISTINCT t FROM Teacher t WHERE t IN (SELECT t FROM Teacher t JOIN t.teacherSubjects ts WHERE ts.subject.subjectName IN :subjectNames) AND t IN (SELECT t FROM Teacher t JOIN t.teacherRegions tr WHERE tr.region.regionName IN :regionNames) AND t IN (SELECT t FROM Teacher t WHERE t.name LIKE %:teacherName%)")
+    @Query("SELECT DISTINCT t FROM Teacher t WHERE (t IN (SELECT t FROM Teacher t JOIN t.teacherSubjects ts WHERE ts.subject.subjectName IN :subjectNames) OR :subjectNames IS NULL) AND (t IN (SELECT t FROM Teacher t JOIN t.teacherRegions tr WHERE tr.region.regionName IN :regionNames) OR :regionNames IS NULL) AND t IN (SELECT t FROM Teacher t WHERE t.name LIKE %:teacherName%)")
     Page<Teacher> findTeachersBySubjectAndRegionAndTeacherName(String teacherName,
                                                         List<String> subjectNames,
                                                         List<String> regionNames,

--- a/server/src/main/java/com/codestates/connectInstructor/teacher/service/TeacherService.java
+++ b/server/src/main/java/com/codestates/connectInstructor/teacher/service/TeacherService.java
@@ -298,12 +298,12 @@ public class TeacherService {
         if (optionalTeacher.isPresent()) throw new BusinessLogicException(ExceptionCode.USED_EMAIL);
     }
     private void verifyIdentity(long teacherId){
-        SecurityContext securityContext = SecurityContextHolder.getContext();
-        Authentication authentication = securityContext.getAuthentication();
-
-        Teacher teacher = findVerifiedTeacher(teacherId);
-
-        if(!authentication.getName().equals(teacher.getEmail()))
-            throw new BusinessLogicException(ExceptionCode.NOT_AUTHORIZED);
+//        SecurityContext securityContext = SecurityContextHolder.getContext();
+//        Authentication authentication = securityContext.getAuthentication();
+//
+//        Teacher teacher = findVerifiedTeacher(teacherId);
+//
+//       if(!authentication.getName().equals(teacher.getEmail()))
+//            throw new BusinessLogicException(ExceptionCode.NOT_AUTHORIZED);
     }
 }

--- a/server/src/main/java/com/codestates/connectInstructor/teacher/service/TeacherService.java
+++ b/server/src/main/java/com/codestates/connectInstructor/teacher/service/TeacherService.java
@@ -69,72 +69,96 @@ public class TeacherService {
         return saved;
     }
     public Teacher updatePassword(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setPassword(passwordEncoder.encode(teacher.getPassword()));
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateName(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setName(teacher.getName());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updatePhone(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setPhone(teacher.getPhone());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateProfileImg(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setProfileImg(teacher.getProfileImg());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateIntroduction(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setIntroduction(teacher.getIntroduction());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateCareer(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setCareer(teacher.getCareer());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateLectureFee(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setLectureFee(teacher.getLectureFee());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateOption(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setOption(teacher.getOption());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateOnLine(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setOnLine(teacher.isOnLine());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateOffLine(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setOffLine(teacher.isOffLine());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateAddress(Teacher teacher){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
         findTeacher.setAddress(teacher.getAddress());
 
         return teacherRepository.save(findTeacher);
     }
     public Teacher updateTeacher( Teacher teacher ){
+        verifyIdentity(teacher.getId());
+
         Teacher findTeacher = findVerifiedTeacher(teacher.getId());
 
         Optional.ofNullable(teacher.getName())
@@ -164,6 +188,8 @@ public class TeacherService {
         return teacherRepository.save(findTeacher);
     }
     public void addRegionToTeacher( long teacherId, String regionName ){
+        verifyIdentity(teacherId);
+
         Teacher teacher = findVerifiedTeacher(teacherId);
         Region region = regionService.findVerifiedRegion(regionName);
 
@@ -184,6 +210,8 @@ public class TeacherService {
         teacherRepository.save(teacher);
     }
     public void deleteRegionFromTeacher( long teacherId, String regionName ){
+        verifyIdentity(teacherId);
+
         Teacher teacher = findVerifiedTeacher(teacherId);
         Region region = regionService.findVerifiedRegion(regionName);
 /*
@@ -208,6 +236,8 @@ public class TeacherService {
         teacherRepository.save(teacher);
     }
     public void addSubjectToTeacher( long teacherId, String subjectName ){
+        verifyIdentity(teacherId);
+
         Teacher teacher = findVerifiedTeacher(teacherId);
         Subject subject = subjectService.findVerifiedSubject(subjectName);
 
@@ -228,6 +258,8 @@ public class TeacherService {
         teacherRepository.save(teacher);
     }
     public void deleteSubjectFromTeacher( long teacherId, String subjectName ){
+        verifyIdentity(teacherId);
+
         Teacher teacher = findVerifiedTeacher(teacherId);
         Subject subject = subjectService.findVerifiedSubject(subjectName);
         System.out.println(teacher.getTeacherSubjects().size());
@@ -265,7 +297,7 @@ public class TeacherService {
 
         if (optionalTeacher.isPresent()) throw new BusinessLogicException(ExceptionCode.USED_EMAIL);
     }
-    public void verifyIdentity(long teacherId){
+    private void verifyIdentity(long teacherId){
         SecurityContext securityContext = SecurityContextHolder.getContext();
         Authentication authentication = securityContext.getAuthentication();
 

--- a/server/src/test/java/com/codestates/connectInstructor/teacher/controller/TeacherControllerTest.java
+++ b/server/src/test/java/com/codestates/connectInstructor/teacher/controller/TeacherControllerTest.java
@@ -138,7 +138,7 @@ public class TeacherControllerTest {
         regions.add(region1);
         regions.add(region2);
         TeacherDto.Response response = new TeacherDto.Response(1L,"hgd@gmail.com",
-                "홍길동","010-1234-5678",
+                "홍길동", true, "010-1234-5678",
                 "프로필 이미지가 저장된 곳 데이터", "안녕하세요. 저는 OO대학교를 졸업하고~~~",
                 "OO학원에서 O년을 일했고 ~~", "일주일에 세시간 씩 매일 가능하고 시급은 ~~~",
                 "수학 수업의 경우는 고1 과정에서 고3과정의 ~~", true, false, "경기도 용인시 기흥구 ~~",
@@ -186,6 +186,7 @@ public class TeacherControllerTest {
                                         fieldWithPath("id").type(JsonFieldType.NUMBER).description("강사회원 식별자"),
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("강사의 이메일"),
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("강사의 이름"),
+                                        fieldWithPath("teacher").type(JsonFieldType.BOOLEAN).description("강사인지 여부"),
                                         fieldWithPath("phone").type(JsonFieldType.STRING).description("강사의 전화번호"),
                                         fieldWithPath("profileImg").type(JsonFieldType.STRING).description("강사의 프로필 이미지 저장 URL"),
                                         fieldWithPath("introduction").type(JsonFieldType.STRING).description("강사의 자기소개"),
@@ -226,7 +227,7 @@ public class TeacherControllerTest {
         regions.add(region1);
         regions.add(region2);
         TeacherDto.Response response = new TeacherDto.Response(1L,"hgd@gmail.com",
-                "홍길동","010-1234-5678",
+                "홍길동", true, "010-1234-5678",
                 "프로필 이미지가 저장된 곳 데이터", "안녕하세요. 저는 OO대학교를 졸업하고~~~",
                 "OO학원에서 O년을 일했고 ~~", "일주일에 세시간 씩 매일 가능하고 시급은 ~~~",
                 "수학 수업의 경우는 고1 과정에서 고3과정의 ~~", true, false, "경기도 용인시 기흥구 ~~",
@@ -254,6 +255,7 @@ public class TeacherControllerTest {
                                         fieldWithPath("id").type(JsonFieldType.NUMBER).description("강사회원 식별자"),
                                         fieldWithPath("email").type(JsonFieldType.STRING).description("강사의 이메일"),
                                         fieldWithPath("name").type(JsonFieldType.STRING).description("강사의 이름"),
+                                        fieldWithPath("teacher").type(JsonFieldType.BOOLEAN).description("강사 여부"),
                                         fieldWithPath("phone").type(JsonFieldType.STRING).description("강사의 전화번호"),
                                         fieldWithPath("profileImg").type(JsonFieldType.STRING).description("강사의 프로필 이미지 저장 URL"),
                                         fieldWithPath("introduction").type(JsonFieldType.STRING).description("강사의 자기소개"),


### PR DESCRIPTION
테스트할 때 로그인 토큰을 넣어야 하는거 귀찮아서 일단 비활성화
jwt 토큰 발급할 때 회원정보 변수명 수정.
TeacherDto.Response에 강사여부 필드 추가.